### PR TITLE
Latency , background noise and crackling fix attempts 

### DIFF
--- a/plugins/unifi-protect/src/main.ts
+++ b/plugins/unifi-protect/src/main.ts
@@ -116,12 +116,18 @@ class UnifiCamera extends ScryptedDeviceBase implements Notifier, Intercom, Came
         const args = ffmpegInput.inputArguments.slice();
 
         args.push(
-            "-acodec", camera.talkbackSettings.typeFmt,
-            "-profile:a", "aac_low",
+            "-acodec", "libfdk_aac",
+            "-profile:a", "aac_he",
+            "-eld_sbr", "1",
+            "-threads", "0",
+            "-avioflags", "direct",
+            "-max_delay", "3000000",
+            "-flush_packets", "1",
+            "-af", "highpass=f=200, lowpass=f=2500, afftdn=tn=1:tr=1",
             "-flags", "+global_header",
             "-ar", camera.talkbackSettings.samplingRate.toString(),
             "-ac", camera.talkbackSettings.channels.toString(),
-            "-b:a", "64k",
+            "-b:a", "16k",
             "-f", "adts",
             `tcp://127.0.0.1:${port}`,
         );


### PR DESCRIPTION
- Moved to libfdk_aac (because it's also used for homekit and has some nicer profiles that can be used)
- use High efficiency profile
- use as many threads as core are available
- avioflag and flush_packages flags to minimise latency
- max_delay to make sure the delay won't grow endlessly
- filter audio below 200hz en above 2500hz and use the afftdn filter to limit background noise and such 
- Limit bitrate to 16K , this seems to help agains crackling sound (maybe because it speeds up transcoding). Audio still seems very acceptable with 16K